### PR TITLE
Fix dependencies and parallel print

### DIFF
--- a/geetiles/cmds.py
+++ b/geetiles/cmds.py
@@ -9,6 +9,7 @@ import geopandas as gpd
 import numpy as np
 import shapely as sh
 from joblib import delayed
+from joblib import Parallel
 from pyproj import CRS
 from progressbar import progressbar as pbar
 from skimage.io import imread
@@ -265,7 +266,7 @@ def build_grid(aoi, chip_size_meters):
     # create a polygon at each point
     print (f"inspecting {gridx*gridy} chips", flush=True)
 
-    parts = utils.mParallel(n_jobs=-1, verbose=30)(delayed(get_polygon)(m, gx, gy, minx, miny) \
+    parts = Parallel(n_jobs=-1, verbose=30)(delayed(get_polygon)(m, gx, gy, minx, miny) \
                                             for gx,gy in itertools.product(range(gridx), range(gridy)))
     parts = [i for i in parts if i is not None and aoi.intersects(i)]
     parts = gpd.GeoDataFrame(parts, columns=['geometry'], crs=epsg4326)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(name='geetiles',
       install_requires=['matplotlib','numpy', 'pandas','joblib',
                         'progressbar2', 'psutil', 'scipy', 'shapely',
                         'geopandas', 'pyproj', 'rasterio', 'retry', 
-                        'earthengine-api', 'alphashape'
+                        'earthengine-api', 'alphashape', 'scikit-image'
                        ],
       use_scm_version=True,
       setup_requires=['setuptools_scm'],


### PR DESCRIPTION
This PR fixes the lack of scikit-image dependencies at `setup.py` #20  and  a `TypeError` on #21 

fixes #20 , closes #21 .

The fix for #21 is lackluster, since it makes the print less pretty. But couldnt find a proper way to fix that message

