### PR TITLE
Update to support new Earth Engine Client requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ this generates file `./lux_partitions_aschips_14c55eb7d417f.geojson`. Use a tool
 
 ### 2. download tiles
 
-    geet download --tiles_file lux_partitions_aschips_14c55eb7d417f.geojson  --dataset_def sentinel2-rgb-median-2020 --pixels_lonlat [100,100] --skip_if_exists
+For this step, you will need a Google Cloud earth engine project configured (as of 13/11/24) - documentation for this can be found [here](https://developers.google.com/earth-engine/guides/access). Make a copy of your project name
+
+    geet download --tiles_file lux_partitions_aschips_14c55eb7d417f.geojson  --dataset_def sentinel2-rgb-median-2020 --pixels_lonlat [100,100] --skip_if_exists --project {EE_PROJECT_NAME}
 
 
 this fills the folder `lux_partitions_aschips_14c55eb7d417f/sentinel2-rgb-median-2020` with RGB geotiff images of size 100x100 pixels.
@@ -45,7 +47,7 @@ If using `esaworldcover-2020` as `dataset_def`, which is an alias to [ESA WorldC
 
 ## Other usages
 
-### Other ways to create the set of tiles (shapes) 
+### Other ways to create the set of tiles (shapes)
 
 - As random partitions with at most 5km size length (figure below left).
 
@@ -93,7 +95,7 @@ With respect to a dataset downloaded with segmentation labels.
 
 We can also add the label proportions of the coarser tile in which each chip is embedded. First, we need to download the labels for each coarser tile from GEE.
 
-    geet download --tiles_file lux_partitions_communes_1a471c686e053.geojson  --dataset_def esa-world-cover  --meters_per_pixel 20  --skip_if_exists 
+    geet download --tiles_file lux_partitions_communes_1a471c686e053.geojson  --dataset_def esa-world-cover  --meters_per_pixel 20  --skip_if_exists
 
 then, compute the label proportions at this coarser tiles:
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If using `esaworldcover-2020` as `dataset_def`, which is an alias to [ESA WorldC
 
 ### Using your own code to define the GEE source image object.
 
-    geet download --tiles_file lux_partitions_aschips_14c55eb7d417f.geojson  --dataset_def crops.py --pixels_lonlat [100,100] --skip_if_exists --skip_confirm --n_processes 20
+    geet download --tiles_file lux_partitions_aschips_14c55eb7d417f.geojson  --dataset_def crops.py --pixels_lonlat [100,100] --skip_if_exists --skip_confirm --n_processes 20 --project {EE_PROJECT_NAME}
 
 where `crops.py` contains a python `class DatasetDefinition` following the structure of the predefined ones under `defs`.  The files `crops.py` will be saved under the destination folder for reference. The destination folder is created alongside the `tiles_file`.
 
@@ -95,7 +95,7 @@ With respect to a dataset downloaded with segmentation labels.
 
 We can also add the label proportions of the coarser tile in which each chip is embedded. First, we need to download the labels for each coarser tile from GEE.
 
-    geet download --tiles_file lux_partitions_communes_1a471c686e053.geojson  --dataset_def esa-world-cover  --meters_per_pixel 20  --skip_if_exists
+    geet download --tiles_file lux_partitions_communes_1a471c686e053.geojson  --dataset_def esa-world-cover  --meters_per_pixel 20  --skip_if_exists --project {EE_PROJECT_NAME}
 
 then, compute the label proportions at this coarser tiles:
 

--- a/geetiles/cmds.py
+++ b/geetiles/cmds.py
@@ -160,15 +160,15 @@ n_processes        {n_processes}
     else:
         ee.Authenticate(auth_mode = ee_auth_mode)
 
-    for i in range(10):
-        try:
-            ee.Initialize(project = ee_project)
-        except Exception as e:
-            if i==9:
-                raise e
-            print ("error initializing gee", e)
-            print ("waiting 2 secs to retry")
-            sleep(2)
+    # for i in range(10):
+    #     try:
+    #         ee.Initialize(project = ee_project)
+    #     except Exception as e:
+    #         if i==9:
+    #             raise e
+    #         print ("error initializing gee", e)
+    #         print ("waiting 2 secs to retry")
+    #         sleep(2)
 
     dataset_name = dataset_definition.get_dataset_name()
 
@@ -193,6 +193,7 @@ n_processes        {n_processes}
         f.write(dataset_def)
 
     p.download_gee_tiles(dataset_definition = dataset_definition,
+                         ee_project = ee_project,
                          meters_per_pixel = meters_per_pixel,
                          pixels_lonlat = pixels_lonlat,
                          dtype = dtype,

--- a/geetiles/cmds.py
+++ b/geetiles/cmds.py
@@ -28,27 +28,27 @@ from . import utils
 epsg4326 = utils.epsg4326
 
 
-def split(tiles_file, 
-          nbands, 
+def split(tiles_file,
+          nbands,
           angle,
-          train_pct, 
-          test_pct, 
+          train_pct,
+          test_pct,
           val_pct,
           foreign_tiles_name=None):
-    
+
     p = partitions.PartitionSet.from_file(tiles_file)
     if foreign_tiles_name is None:
-        p.split(nbands=nbands, angle=angle, 
+        p.split(nbands=nbands, angle=angle,
                         train_pct=train_pct, test_pct=test_pct, val_pct=val_pct)
     else:
-        p.split_per_partitions(nbands=nbands, angle=angle, 
-                            train_pct=train_pct, test_pct=test_pct, val_pct=val_pct, 
+        p.split_per_partitions(nbands=nbands, angle=angle,
+                            train_pct=train_pct, test_pct=test_pct, val_pct=val_pct,
                             other_partitions_id=foreign_tiles_name)
     p.save_splits()
 
-def label_proportions_compute(tiles_file, 
+def label_proportions_compute(tiles_file,
                               labels_dataset_def):
-    
+
     label_dataset_definition = utils.get_dataset_definition(labels_dataset_def)
     print ("loading tiles from", tiles_file, flush=True)
     p = partitions.PartitionSet.from_file(tiles_file)
@@ -68,9 +68,9 @@ def label_proportions_from_foreign(tiles_file,
     print ("loading primary tiles from", tiles_file, flush=True)
     p = partitions.PartitionSet.from_file(tiles_file)
     print ("loading foreign tiles from", foreign_tiles_file, flush=True)
-    t = partitions.PartitionSet.from_file(foreign_tiles_file) 
+    t = partitions.PartitionSet.from_file(foreign_tiles_file)
     print ("intersecting geometries and computing label proportions from foreign tiles", flush=True)
-    p.add_foreign_proportions(label_dataset_definition, t)    
+    p.add_foreign_proportions(label_dataset_definition, t)
     print ("done!")
 
 
@@ -78,24 +78,25 @@ def intersect_with_foreign(tiles_file, foreign_tiles_file):
     print ("loading primary tiles from", tiles_file, flush=True)
     p = partitions.PartitionSet.from_file(tiles_file)
     print ("loading foreign tiles from", foreign_tiles_file, flush=True)
-    t = partitions.PartitionSet.from_file(foreign_tiles_file) 
+    t = partitions.PartitionSet.from_file(foreign_tiles_file)
     print ("intersecting geometries with foreign tiles", flush=True)
-    p.add_foreign_partition(t)    
+    p.add_foreign_partition(t)
     print ("done!")
 
 
-def download(tiles_file, 
-             dataset_def, 
-             pixels_lonlat, meters_per_pixel, 
+def download(tiles_file,
+             dataset_def,
+             pixels_lonlat, meters_per_pixel,
              max_downloads,
              shuffle,
              skip_if_exists,
              ee_auth_mode,
              n_processes,
+             ee_project,
              groups = None,
              aoi = None,
              skip_confirm=False):
-    
+
     # sanity check
     if (pixels_lonlat is None and meters_per_pixel is None) or\
        (pixels_lonlat is not None and meters_per_pixel is not None):
@@ -115,7 +116,7 @@ def download(tiles_file,
 
     groups_str = f'groups             {groups}' if groups is not None else ''
     aoi_str    = f'aoi                {aoi}' if aoi is not None else ''
-    
+
     print (f"""
 using the following download specficication
 
@@ -132,36 +133,36 @@ n_processes        {n_processes}
 {groups_str}
 {aoi_str}
         """)
-    
+
     if not skip_confirm:
         while True:
-            yesno = input("confirm (y/N): ")        
+            yesno = input("confirm (y/N): ")
             yesno = yesno.lower()
             if yesno.strip()=='':
                 yesno = 'n'
             if yesno in ['y', 'n', 'yes', 'no']:
                 break
-        
+
         if yesno in ['n', 'no']:
             print ("abort!!")
             return
-        
+
     # authenticate on google earth engine
     print ("authenticating to Google Earth Engine")
     if ee_auth_mode is None:
         try:
             print ("trying to use default gee credentials")
-            ee.Authenticate(auth_mode = 'appdefault')    
+            ee.Authenticate(auth_mode = 'appdefault')
         except:
             print ("could not authenticate with default gee credentials, using auth_method = 'notebook'")
             ee.Authenticate(auth_mode = 'notebook')
-        
+
     else:
         ee.Authenticate(auth_mode = ee_auth_mode)
 
     for i in range(10):
         try:
-            ee.Initialize()
+            ee.Initialize(project = ee_project)
         except Exception as e:
             if i==9:
                 raise e
@@ -191,15 +192,15 @@ n_processes        {n_processes}
     with open(f"{dest_dir}.dataset_def.py", "w") as f:
         f.write(dataset_def)
 
-    p.download_gee_tiles(dataset_definition = dataset_definition, 
-                         meters_per_pixel = meters_per_pixel, 
+    p.download_gee_tiles(dataset_definition = dataset_definition,
+                         meters_per_pixel = meters_per_pixel,
                          pixels_lonlat = pixels_lonlat,
-                         dtype = dtype, 
+                         dtype = dtype,
                          shuffle = shuffle,
                          skip_if_exists = skip_if_exists,
                          n_processes = n_processes,
                          max_downloads=max_downloads)
-    
+
     print("\ndone.")
 
 def make_random_partitions(aoi_wkt_file, max_rectangle_size_meters, aoi_name, dest_dir, random_variance=0.1, ):
@@ -207,13 +208,13 @@ def make_random_partitions(aoi_wkt_file, max_rectangle_size_meters, aoi_name, de
     makes random partitions of the aoi
     """
     with open(aoi_wkt_file, "r") as f:
-        aoi = wkt.loads(f.read()) 
-        
+        aoi = wkt.loads(f.read())
+
     parts = partitions.PartitionSet(aoi_name, region=aoi)
     parts.reset_data().make_random_partitions(max_rectangle_size=max_rectangle_size_meters, random_variance=random_variance)
     print()
     parts.save_as(dest_dir, f'{max_rectangle_size_meters//1000}k')
-    
+
     return parts.data
 
 def show_aois():
@@ -290,10 +291,10 @@ def extract_aoi(aoiname):
         print (f"aoi saved to '{fname}'")
 
 def make_grid(aoi_wkt_file, chip_size_meters, aoi_name, dest_dir):
-    
+
     with open(aoi_wkt_file, "r") as f:
-        aoi = wkt.loads(f.read()) 
-            
+        aoi = wkt.loads(f.read())
+
     grid = build_grid(aoi=aoi, chip_size_meters=chip_size_meters)
     parts = partitions.PartitionSet(aoi_name, data=grid)
     print()
@@ -303,7 +304,7 @@ def make_grid(aoi_wkt_file, chip_size_meters, aoi_name, dest_dir):
 def build_grid(aoi, chip_size_meters):
     """
     make a grid of squared tiles. The resulting tiles sides have
-    constant lat and lon, as required by GEE, otherwise unaligned geometries 
+    constant lat and lon, as required by GEE, otherwise unaligned geometries
     produce null pixels on the borders, when extracting the geometry from gee.
 
     aoi: a shapely object with the geometry to cover. must be in degrees (epsg4326)
@@ -312,7 +313,7 @@ def build_grid(aoi, chip_size_meters):
     returns: a GeoPandas dataframe in epsg4326
     """
     m = chip_size_meters
-    
+
     # make a grid of points using utm crs
     aoi_utm = utils.get_utm_crs(*list(aoi.centroid.coords)[0])
     aoim = gpd.GeoDataFrame({'geometry': [aoi]}, crs=epsg4326).to_crs(aoi_utm).geometry[0]
@@ -324,7 +325,7 @@ def build_grid(aoi, chip_size_meters):
     rangey = maxy-miny
     gridx = int(rangex//m)
     gridy = int(rangey//m)
-    
+
     def get_polygon(m, gx, gy, minx, miny):
 
         rlon, rlat = gx*m+minx, gy*m+miny
@@ -337,7 +338,7 @@ def build_grid(aoi, chip_size_meters):
 
         # obtain how many meters per degree lon and lat in this region of the globe.
         # by doing the aritmethic in degrees (not in meters) we ensure tile sides have
-        # constant lat and lon, as required by GEE, otherwise unaligned geometries 
+        # constant lat and lon, as required by GEE, otherwise unaligned geometries
         # produce null pixels on the borders.
         lon0,lat0 = list(gpd.GeoSeries([sh.geometry.Point([clon, clat])], crs=epsg4326).to_crs(aoi_utm).values[0].coords)[0]
         lon1,lat1 = list(gpd.GeoSeries([sh.geometry.Point([clon+0.001, clat])], crs=epsg4326).to_crs(aoi_utm).values[0].coords)[0]
@@ -348,14 +349,14 @@ def build_grid(aoi, chip_size_meters):
         delta_degrees_lon =  ((m-1)/2) / meters_per_degree_lon
         delta_degrees_lat =  ((m-1)/2) / meters_per_degree_lat
 
-        part =  sh.geometry.Polygon([[clon-delta_degrees_lon, clat-delta_degrees_lat], 
+        part =  sh.geometry.Polygon([[clon-delta_degrees_lon, clat-delta_degrees_lat],
                                      [clon-delta_degrees_lon, clat+delta_degrees_lat],
                                      [clon+delta_degrees_lon, clat+delta_degrees_lat],
                                      [clon+delta_degrees_lon, clat-delta_degrees_lat],
-                                     [clon-delta_degrees_lon, clat-delta_degrees_lat]])    
-        return part    
-    
-    
+                                     [clon-delta_degrees_lon, clat-delta_degrees_lat]])
+        return part
+
+
     # create a polygon at each point
     print (f"inspecting {gridx*gridy} chips", flush=True)
 
@@ -377,10 +378,10 @@ def select_partitions(orig_shapefile, aoi_wkt_file, aoi_name, tiles_name, dest_d
     if not  parts.crs == epsg4326:
            raise ValueError("'orig_shapefile' must be in epsg4326, lon/lat degrees "+\
                             f"but found \n{parts.crs}")
-    
+
     with open(aoi_wkt_file, "r") as f:
-        aoi = wkt.loads(f.read()) 
-    
+        aoi = wkt.loads(f.read())
+
     print ("selecting geometries", flush=True)
     parts = [p for p in pbar(parts.geometry) if p.intersects(aoi)]
     if len(parts)==0:
@@ -388,7 +389,7 @@ def select_partitions(orig_shapefile, aoi_wkt_file, aoi_name, tiles_name, dest_d
     # very small intersections probably are cause by numerical approximations
     # on the borders of the aoi
     parts = [p for p in parts if p.intersection(aoi).area>1e-5]
-    
+
     parts = gpd.GeoDataFrame({'geometry': parts}, crs = CRS.from_epsg(4326))
     parts.to_file("/tmp/bb.geojson", driver='GeoJSON')
     parts = partitions.PartitionSet(aoi_name, data=parts)
@@ -397,12 +398,12 @@ def select_partitions(orig_shapefile, aoi_wkt_file, aoi_name, tiles_name, dest_d
 
     return parts
 
-def zip_dataset(tiles_file, 
+def zip_dataset(tiles_file,
                 foreign_tiles_file,
-                images_dataset_def, 
-                labels_dataset_def, 
+                images_dataset_def,
+                labels_dataset_def,
                 readme_file):
-    
+
 
     images_dataset = utils.get_dataset_definition(images_dataset_def)
     images_dataset_name = images_dataset.get_dataset_name()
@@ -431,7 +432,7 @@ def zip_dataset(tiles_file,
         foreign_tiles_name = s[s.find('_partitions_')+len('_partitions_'):].split("_")[0]
     else:
         foreign_tiles_name = None
-        
+
     print ("preparing folders")
     os.makedirs(f"{destination_dir}/data", exist_ok=True)
 
@@ -442,9 +443,9 @@ def zip_dataset(tiles_file,
         elif filebase.endswith('_expanded'):
             r = "_".join(filebase.split("_")[:-2])+"_expanded"+extension
         else:
-            r = "_".join(filebase.split("_")[:-1])+extension            
+            r = "_".join(filebase.split("_")[:-1])+extension
         return r
-    
+
     print ("creating expanded file for easy visualization of label proportions")
     p = partitions.PartitionSet.from_file(tiles_file)
     p.expand_proportions()
@@ -475,7 +476,7 @@ def zip_dataset(tiles_file,
     print ("reading tiles file")
     # read chip definitions
     c = gpd.read_file(tiles_file)
-    # gather imgs, labels and proportions 
+    # gather imgs, labels and proportions
     partitionset_dir = os.path.splitext(f"{basedir}/{tiles_file}")[0]
     n_skipped_chips = 0
     n_included_chips = 0
@@ -492,19 +493,19 @@ def zip_dataset(tiles_file,
             img = imread(img_filename).astype(np.int16)
             if 'map_values' in dir(images_dataset):
                 img = images_dataset.map_values(img)
-            
+
             coords = np.r_[i.geometry.envelope.boundary.coords]
             center_latlon = coords.mean(axis=0)[::-1]
             cmax = coords.max(axis=0)[::-1]
             cmin = coords.min(axis=0)[::-1]
             nw = np.r_[cmax[0], cmin[1]]
-            se = np.r_[cmin[0], cmax[1]]    
+            se = np.r_[cmin[0], cmax[1]]
 
             r['chip'] = img
             r['chip_id'] = i.identifier
             r['center_latlon'] = center_latlon
             r['corners'] = { 'nw': nw, 'se': se }
-            
+
             if labels_dataset_name is not None and os.path.exists(label_filename):
                 label = imread(label_filename).astype(np.int16)
                 if 'map_values' in dir(labels_dataset):
@@ -579,14 +580,14 @@ def get_bounds(raster_file):
     src.close()
     return np.r_[[w,s,e,n]]
 
-    
+
 def get_resized_img_with_pixel_coords(raster_file, utm_crs, min_lonlat_meters, meters_per_pixel):
     """
-    reads an image 
+    reads an image
     """
-    
+
     epsg4326 = CRS.from_epsg(4326)
-    
+
     # read image
 
     try:
@@ -594,17 +595,17 @@ def get_resized_img_with_pixel_coords(raster_file, utm_crs, min_lonlat_meters, m
             w,s,e,n = src.bounds
             img = src.read()
             img = np.transpose(img, [2,1,0])
-            
-        # transform dimensions into pixel coords    
+
+        # transform dimensions into pixel coords
         coords = np.r_[list(gpd.GeoDataFrame([], geometry=[sh.geometry.Polygon([[w,n], [w,s], [e,s], [e,n]])], crs=epsg4326).to_crs(utm_crs).geometry.values[0].boundary.coords)]
         sw_corner_lonlat_meters = coords[1]
 
         coords_pixels = np.ceil((coords - min_lonlat_meters) / meters_per_pixel).astype(int)
-        sw_lonlat_pixels = np.ceil((sw_corner_lonlat_meters - min_lonlat_meters) / meters_per_pixel).astype(int) 
+        sw_lonlat_pixels = np.ceil((sw_corner_lonlat_meters - min_lonlat_meters) / meters_per_pixel).astype(int)
 
         patch_size = coords_pixels[2,0] - coords_pixels[1,0], coords_pixels[3,1] - coords_pixels[2,1]
 
-        # resize and rotate img 
+        # resize and rotate img
         rotate_x = coords_pixels[0,0] - coords_pixels[1,0]
         rotate_y = coords_pixels[1,1] - coords_pixels[2,1]
         rotate_x = patch_size[1]
@@ -621,11 +622,11 @@ def get_resized_img_with_pixel_coords(raster_file, utm_crs, min_lonlat_meters, m
     except:
         x0,x1,y0,y1,img_resized = [None]*5
 
-    return x0,x1, y0,y1, img_resized    
+    return x0,x1, y0,y1, img_resized
 
-def make_mosaic(basedir, meters_per_pixel, dest_file, channels=None):    
+def make_mosaic(basedir, meters_per_pixel, dest_file, channels=None):
     """
-    creates a mosaic of all tifs found in a folder. assumes all tiffs use the same numeric 
+    creates a mosaic of all tifs found in a folder. assumes all tiffs use the same numeric
     type and all pixels are non-zero (i.e, from rectangular grid)
 
     basedir:           the folder to look for tiffs (not recursively)
@@ -640,35 +641,35 @@ def make_mosaic(basedir, meters_per_pixel, dest_file, channels=None):
     epsg4326 = CRS.from_epsg(4326)
 
     fnames = sorted(os.listdir(basedir))
-    
-    print (f"computing resulting mosaic image size for {len(fnames)} files", flush=True) 
+
+    print (f"computing resulting mosaic image size for {len(fnames)} files", flush=True)
     bounds = utils.mParallel(n_jobs=-1, verbose=30)(delayed(get_bounds)(f"{basedir}/{fname}") for fname in fnames)
     bounds = np.r_[bounds]
 
     # compute meters utm corresponding to the mean location of all geometries
     coords      = np.vstack([bounds[:, :2], bounds[:,2:]])
-    
+
     mean_lonlat = coords.mean(axis=0)
     utm_crs     = utils.get_utm_crs(*mean_lonlat)
     min_lonlat  = coords.min(axis=0)
     max_lonlat  = coords.max(axis=0)
-    
+
     # compute bounding rectangle bounds in meters
-    min_lonlat_meters, max_lonlat_meters = gpd.GeoDataFrame([], 
-                                                            geometry=[sh.geometry.Point(min_lonlat), sh.geometry.Point(max_lonlat)], 
+    min_lonlat_meters, max_lonlat_meters = gpd.GeoDataFrame([],
+                                                            geometry=[sh.geometry.Point(min_lonlat), sh.geometry.Point(max_lonlat)],
                                                             crs=epsg4326)\
                                               .to_crs(utm_crs).geometry.values
 
     min_lonlat_meters, max_lonlat_meters = np.r_[min_lonlat_meters.coords][0], np.r_[max_lonlat_meters.coords][0]
-    
+
     # compute dimensions of resulting image
     img_dim_x, img_dim_y = np.round((max_lonlat_meters - min_lonlat_meters)  / meters_per_pixel).astype(int)
-    
+
     # get type of resulting tiff by opening any file
     src = rasterio.open(f"{basedir}/{fnames[0]}")
     r = np.zeros([img_dim_x, img_dim_y, len(channels)], dtype=src.dtypes[0])
     src.close()
-    
+
     print ("\nreading and resizing images", flush=True)
     imgs_and_coords = utils.mParallel(n_jobs=-1, verbose=30)(delayed(get_resized_img_with_pixel_coords)(f"{basedir}/{fname}", utm_crs, min_lonlat_meters, meters_per_pixel) for fname in fnames)
 
@@ -684,9 +685,9 @@ def make_mosaic(basedir, meters_per_pixel, dest_file, channels=None):
     # transpose x and y, and flip
     r = np.transpose(r, [1,0,2])
     r = r[::-1, :, :]
-        
+
     left, top = min_lonlat_meters[0], max_lonlat_meters[1]
-    resx, resy = (max_lonlat_meters - min_lonlat_meters) / np.r_[r.shape[:2]] 
+    resx, resy = (max_lonlat_meters - min_lonlat_meters) / np.r_[r.shape[:2]]
     transform = from_origin(left, top, meters_per_pixel, meters_per_pixel)
     with rasterio.open(dest_file, 'w', driver='GTiff',
                     height = r.shape[0], width = r.shape[1],
@@ -743,14 +744,14 @@ def cleanup(basedir):
 
 def get_pixels_with_coords(bounds, fill_value, utm_crs, min_lonlat_meters, meters_per_pixel, dtype):
     """
-    bounds: a tuple with (w,s,e,n) 
-    
+    bounds: a tuple with (w,s,e,n)
+
     """
     epsg4326 = CRS.from_epsg(4326)
     w,s,e,n  = bounds
 
     coords = np.r_[list(gpd.GeoDataFrame([], geometry=[sh.geometry.Polygon([[w,n], [w,s], [e,s], [e,n]])], crs=epsg4326).to_crs(utm_crs).geometry.values[0].boundary.coords)]
-    sw_corner_lonlat_meters = coords[1] 
+    sw_corner_lonlat_meters = coords[1]
 
     coords_pixels = np.ceil((coords - min_lonlat_meters) / meters_per_pixel).astype(int)
 
@@ -760,11 +761,11 @@ def get_pixels_with_coords(bounds, fill_value, utm_crs, min_lonlat_meters, meter
     coords_pixels[2] += np.r_[[+w,-w]]
     coords_pixels[3] += np.r_[[+w,+w]]
 
-    sw_lonlat_pixels = np.ceil((sw_corner_lonlat_meters - min_lonlat_meters) / meters_per_pixel).astype(int) 
+    sw_lonlat_pixels = np.ceil((sw_corner_lonlat_meters - min_lonlat_meters) / meters_per_pixel).astype(int)
 
     patch_size = coords_pixels[2,0] - coords_pixels[1,0], coords_pixels[3,1] - coords_pixels[2,1]
 
-    # resize and rotate img 
+    # resize and rotate img
     rotate_x = coords_pixels[0,0] - coords_pixels[1,0]
     rotate_y = coords_pixels[1,1] - coords_pixels[2,1]
     rotate_x = patch_size[1]
@@ -774,16 +775,16 @@ def get_pixels_with_coords(bounds, fill_value, utm_crs, min_lonlat_meters, meter
     rotated_patch_size = img_resized.shape[:2]
 
     x0, x1 = sw_lonlat_pixels[0], sw_lonlat_pixels[0] + rotated_patch_size[0]
-    y0, y1 = sw_lonlat_pixels[1] - rotate_y, sw_lonlat_pixels[1] + rotated_patch_size[1] - rotate_y 
+    y0, y1 = sw_lonlat_pixels[1] - rotate_y, sw_lonlat_pixels[1] + rotated_patch_size[1] - rotate_y
 
-    return x0,x1, y0,y1, img_resized    
+    return x0,x1, y0,y1, img_resized
 
 
 def make_mosaic_for_tilevalues(tiles_file, meters_per_pixel, dest_file, dtype=np.float32):
 
     print (f"reading tiles file from {tiles_file}")
     zc = gpd.read_file(tiles_file)
-    
+
     epsg4326 = CRS.from_epsg(4326)
 
     # compute bounding coordinates
@@ -796,8 +797,8 @@ def make_mosaic_for_tilevalues(tiles_file, meters_per_pixel, dest_file, dtype=np
     max_lonlat  = coords.max(axis=0)
 
     # compute bounding rectangle bounds in meters
-    min_lonlat_meters, max_lonlat_meters = gpd.GeoDataFrame([], 
-                                                            geometry=[sh.geometry.Point(min_lonlat), sh.geometry.Point(max_lonlat)], 
+    min_lonlat_meters, max_lonlat_meters = gpd.GeoDataFrame([],
+                                                            geometry=[sh.geometry.Point(min_lonlat), sh.geometry.Point(max_lonlat)],
                                                             crs=epsg4326)\
                                               .to_crs(utm_crs).geometry.values
 
@@ -806,10 +807,10 @@ def make_mosaic_for_tilevalues(tiles_file, meters_per_pixel, dest_file, dtype=np
     # compute dimensions of resulting image
     img_dim_x, img_dim_y = np.round((max_lonlat_meters - min_lonlat_meters)  / meters_per_pixel).astype(int)
 
-    
+
     # compute bounding rectangle bounds in meters
-    min_lonlat_meters, max_lonlat_meters = gpd.GeoDataFrame([], 
-                                                            geometry=[sh.geometry.Point(min_lonlat), sh.geometry.Point(max_lonlat)], 
+    min_lonlat_meters, max_lonlat_meters = gpd.GeoDataFrame([],
+                                                            geometry=[sh.geometry.Point(min_lonlat), sh.geometry.Point(max_lonlat)],
                                                             crs=epsg4326)\
                                               .to_crs(utm_crs).geometry.values
 
@@ -823,8 +824,8 @@ def make_mosaic_for_tilevalues(tiles_file, meters_per_pixel, dest_file, dtype=np
     imgs_and_coords = utils.mParallel(n_jobs=-1, verbose=30)(delayed(get_pixels_with_coords)(t.geometry.bounds, t.value, utm_crs, min_lonlat_meters, meters_per_pixel, dtype) for _,t in zc.iterrows())
 
     # compute bounding rectangle bounds in meters
-    min_lonlat_meters, max_lonlat_meters = gpd.GeoDataFrame([], 
-                                                            geometry=[sh.geometry.Point(min_lonlat), sh.geometry.Point(max_lonlat)], 
+    min_lonlat_meters, max_lonlat_meters = gpd.GeoDataFrame([],
+                                                            geometry=[sh.geometry.Point(min_lonlat), sh.geometry.Point(max_lonlat)],
                                                             crs=epsg4326)\
                                               .to_crs(utm_crs).geometry.values
 
@@ -847,9 +848,9 @@ def make_mosaic_for_tilevalues(tiles_file, meters_per_pixel, dest_file, dtype=np
     # transpose x and y, and flip
     r = np.transpose(r, [1,0,2])
     r = r[::-1, :, :]
-    
+
     left, top = min_lonlat_meters[0], max_lonlat_meters[1]
-    resx, resy = (max_lonlat_meters - min_lonlat_meters) / np.r_[r.shape[:2]] 
+    resx, resy = (max_lonlat_meters - min_lonlat_meters) / np.r_[r.shape[:2]]
     transform = from_origin(left, top, meters_per_pixel, meters_per_pixel)
     with rasterio.open(dest_file, 'w', driver='GTiff',
                     height = r.shape[0], width = r.shape[1],

--- a/geetiles/gee.py
+++ b/geetiles/gee.py
@@ -84,10 +84,6 @@ def _get_tile_byparts(progress_seq, gee_tile, total_size, max_size):
 def _get_tile(progress_seq, gee_tile, bands=None, filename_postfix='', n_retries=3):
     # helper function to download gee tiles
 
-    # print ee auth
-    ee.Initialize(project="ee-bde")
-
-
     for _ in range(n_retries):
         try:
             gee_tile.get_tile(bands=bands, filename_postfix=filename_postfix)

--- a/geetiles/gee.py
+++ b/geetiles/gee.py
@@ -19,7 +19,7 @@ epsg4326 = utils.epsg4326
 
 _gee_get_tile_progress_period = 100
 
-exceeded_size_regexp = "Total request size \((.*) bytes\) must be less than or equal to (.*) bytes"
+exceeded_size_regexp = r"Total request size \((.*) bytes\) must be less than or equal to (.*) bytes"
 
 def _get_tile_byparts(progress_seq, gee_tile, total_size, max_size):
     """
@@ -32,18 +32,18 @@ def _get_tile_byparts(progress_seq, gee_tile, total_size, max_size):
     bands = [v['id'] for v in info['bands']]
     nbands = len(bands)
     # consider bands are larger due to overheads in http, etc.
-    size_per_band = 1.5 * total_size / nbands  
+    size_per_band = 1.5 * total_size / nbands
 
     if size_per_band>max_size:
         raise ValueError(f"image has {nbands} bands and a total size of {total_size}. cannot fit to a max size of {max_size}")
 
-    # split bands to download separate sets within allowed size                    
+    # split bands to download separate sets within allowed size
     bands_per_split = int(np.floor(max_size / size_per_band))
 
     split_idxs = list(range(0, nbands, bands_per_split))
     if split_idxs[-1]!=nbands+1:
         split_idxs.append(nbands+1)
-    
+
     band_sets = [bands[split_idxs[i]:split_idxs[i+1]] for i in range(len(split_idxs)-1)]
 
     # download each band set
@@ -69,7 +69,7 @@ def _get_tile_byparts(progress_seq, gee_tile, total_size, max_size):
     profile['count'] = len(x)
 
     # write single file
-    with rasterio.open(filename, 'w', **profile) as dest:    
+    with rasterio.open(filename, 'w', **profile) as dest:
         dest.write(x)
         for i in range(len(d)):
             dest.set_band_description(i+1, d[i])
@@ -83,6 +83,11 @@ def _get_tile_byparts(progress_seq, gee_tile, total_size, max_size):
 
 def _get_tile(progress_seq, gee_tile, bands=None, filename_postfix='', n_retries=3):
     # helper function to download gee tiles
+
+    # print ee auth
+    ee.Initialize(project="ee-bde")
+
+
     for _ in range(n_retries):
         try:
             gee_tile.get_tile(bands=bands, filename_postfix=filename_postfix)
@@ -107,16 +112,16 @@ def _get_tile(progress_seq, gee_tile, bands=None, filename_postfix='', n_retries
             else:
                 print (f"\n----error getting tile {gee_tile.identifier}\n----", e, "\n----waiting 2secs and retrying")
                 sleep(2)
-        
+
 
     if progress_seq is not None and progress_seq%_gee_get_tile_progress_period==0:
         print (f"{progress_seq} ", end="", flush=True)
 
-def get_gee_tiles(self, 
-                    dataset_definition, 
-                    dest_dir=".", 
-                    file_prefix="geetile_", 
-                    pixels_lonlat=None, 
+def get_gee_tiles(self,
+                    dataset_definition,
+                    dest_dir=".",
+                    file_prefix="geetile_",
+                    pixels_lonlat=None,
                     meters_per_pixel=None,
                     remove_saturated_or_null = False,
                     dtype = None,
@@ -126,7 +131,7 @@ def get_gee_tiles(self,
         r.append(GEETile(dataset_definition=dataset_definition,
                         tile_geometry = g,
                         identifier = i,
-                        dest_dir = dest_dir, 
+                        dest_dir = dest_dir,
                         file_prefix = file_prefix,
                         pixels_lonlat = pixels_lonlat,
                         meters_per_pixel = meters_per_pixel,
@@ -134,18 +139,31 @@ def get_gee_tiles(self,
                         dtype = dtype,
                         skip_if_exists = skip_if_exists)
                 )
-    return r    
+    return r
+
+
+def initialize_ee(ee_project):
+    for i in range(10):
+        try:
+            ee.Initialize(project = ee_project)
+        except Exception as e:
+            if i==9:
+                raise e
+            print ("error initializing gee", e)
+            print ("waiting 2 secs to retry")
+            sleep(2)
 
 
 def download_tiles(
                     data,
                     dest_dir,
-                    dataset_definition, 
-                    n_processes=10, 
-                    pixels_lonlat=None, 
+                    dataset_definition,
+                    ee_project,
+                    n_processes=10,
+                    pixels_lonlat=None,
                     meters_per_pixel=None,
                     remove_saturated_or_null = False,
-                    max_downloads=None, 
+                    max_downloads=None,
                     shuffle=True,
                     skip_if_exists = False,
                     dtype = None):
@@ -153,13 +171,13 @@ def download_tiles(
     """
     downloads in parallel tiles from GEE. See GEETile below for parameters info.
     data: a geopandas dataframe with columns 'geometry' and 'identifier'
-    """        
+    """
     if not data.crs == epsg4326:
            raise ValueError("'data' must be in epsg4326, lon/lat degrees "+\
                             f"when downloading gee tiles, but found \n{data.crs}")
-    
+
     global _gee_get_tile_progress_period
-        
+
     os.makedirs(dest_dir, exist_ok=True)
 
     if dtype is None:
@@ -170,7 +188,7 @@ def download_tiles(
         gtiles.append(GEETile(dataset_definition=dataset_definition,
                         tile_geometry = g,
                         identifier = i,
-                        dest_dir = dest_dir, 
+                        dest_dir = dest_dir,
                         file_prefix = "",
                         pixels_lonlat = pixels_lonlat,
                         meters_per_pixel = meters_per_pixel,
@@ -184,21 +202,22 @@ def download_tiles(
     if max_downloads is not None:
         gtiles = gtiles[:max_downloads]
 
-    print (f"downloading {len(gtiles)} tiles. showing progress of {n_processes} parallel download jobs.", flush=True)                                    
+    print (f"downloading {len(gtiles)} tiles. showing progress of {n_processes} parallel download jobs.", flush=True)
     _gee_get_tile_progress_period = np.max([len(gtiles)//100,1])
-    pool = multiprocessing.Pool(n_processes)
+    # pool = multiprocessing.Pool(n_processes)
+    pool = multiprocessing.Pool(n_processes, initializer=initialize_ee, initargs=(ee_project,))
     pool.starmap(_get_tile, enumerate(gtiles))
     pool.close()
 
 class GEETile:
-    
-    def __init__(self, 
-                 tile_geometry, 
+
+    def __init__(self,
+                 tile_geometry,
                  dataset_definition,
-                 dest_dir=".", 
-                 file_prefix="geetile_", 
-                 meters_per_pixel=None, 
-                 pixels_lonlat=None, 
+                 dest_dir=".",
+                 file_prefix="geetile_",
+                 meters_per_pixel=None,
+                 pixels_lonlat=None,
                  identifier=None,
                  remove_saturated_or_null = False,
                  dtype = None,
@@ -213,9 +232,9 @@ class GEETile:
         remove_saturated_or_null: if true, will remove image if saturated or null > 1%
         """
 
-        if sum([(meters_per_pixel is None), (pixels_lonlat is None)])!=1: 
+        if sum([(meters_per_pixel is None), (pixels_lonlat is None)])!=1:
             raise ValueError("must specify exactly one of meters_per_pixel or pixels_lonlat")
-            
+
         self.tile_geometry = tile_geometry
         self.meters_per_pixel = meters_per_pixel
         self.dataset_definition = dataset_definition
@@ -230,7 +249,7 @@ class GEETile:
             self.identifier = utils.get_region_hash(self.tile_geometry)
         else:
             self.identifier = identifier
-                    
+
         if pixels_lonlat is not None:
             self.pixels_lon, self.pixels_lat = pixels_lonlat
 
@@ -258,7 +277,7 @@ class GEETile:
                 print ("skipping", filename)
                 return
 
-        # get appropriate utm crs for this tile_geometry to measure stuff in meters 
+        # get appropriate utm crs for this tile_geometry to measure stuff in meters
         lon, lat = list(self.tile_geometry.envelope.boundary.coords)[0]
         utm_crs = utils.get_utm_crs(lon, lat)
         self.tile_geometry_utm = gpd.GeoDataFrame({'geometry': [self.tile_geometry]}, crs = CRS.from_epsg(4326)).to_crs(utm_crs).geometry[0]
@@ -272,10 +291,10 @@ class GEETile:
         dims = f"{self.pixels_lon}x{self.pixels_lat}"
 
         try:
-            rectangle = ee.Geometry.Polygon(list(self.tile_geometry.boundary.coords)) 
+            rectangle = ee.Geometry.Polygon(list(self.tile_geometry.boundary.coords))
         except:
             # in case multipolygon, or mutipart or other shapely geometries without a boundary
-            rectangle = ee.Geometry.Polygon(list(self.tile_geometry.envelope.boundary.coords)) 
+            rectangle = ee.Geometry.Polygon(list(self.tile_geometry.envelope.boundary.coords))
 
         image = self.dataset_definition.get_gee_image(tile_geometry = self.tile_geometry)
 
@@ -310,7 +329,7 @@ class GEETile:
                 raise(e)
 
         band_names = image.bandNames().getInfo()
-    
+
         # download and save to tiff
         r = requests.get(url, stream=True)
 
@@ -338,7 +357,7 @@ class GEETile:
             os.remove(filename)
 
         with rasterio.open(filename, "w", **out_meta) as dest:
-            dest.write(out_image)  
+            dest.write(out_image)
             for i in range(out_image.shape[0]):
                 if self.dtype is not None:
                     dest.write_band(i+1, out_image[i]  )

--- a/geetiles/partitions.py
+++ b/geetiles/partitions.py
@@ -19,14 +19,14 @@ epsg4326 = utils.epsg4326
 
 
 class PartitionSet:
-    
+
     def __init__(self, name, region=None, data=None):
         """
         name: a name for this partition
         region: a shapely shape in epsg 4326 lon/lat coords
         data: a geopandas dataframe with the partition list
         """
-        
+
         assert region is not None or data is not None, "must specify either region or data"
         assert (region is not None) + (data is not None) == 1, "cannot specify both region and data"
         assert not "_" in name, "'name' cannot contain '_'"
@@ -34,34 +34,34 @@ class PartitionSet:
         self.region = region
         self.region_utm = None
         self.data   = data
-        
+
         if self.data is not None:
             if self.data.crs == CRS.from_epsg(4326):
                 # convert to meters crs to measure areas
                 lon,lat = np.r_[sh.geometry.GeometryCollection(self.data.geometry.values).envelope.boundary.coords].mean(axis=0)
                 datam = self.data.to_crs(utils.get_utm_crs(lon, lat))
                 self.data['area_km2'] = [i.area/1e6 for i in datam.geometry]
-            else: 
-                # if we are not in epsg 4326 assume we have a crs using meters           
+            else:
+                # if we are not in epsg 4326 assume we have a crs using meters
                 self.data['area_km2'] = [i.area/1e6 for i in self.data.geometry]
 
             self.data = self.data.to_crs(CRS.from_epsg(4326))
             self.data['identifier'] = [utils.get_region_hash(i) for i in self.data.geometry]
-            
+
         self.loaded_from_file = False
 
     def compute_region_utm(self):
         """
-        compute the region covered by this partitionset by joining all geometries in 
+        compute the region covered by this partitionset by joining all geometries in
         the corresponding geopandas dataframe
         """
 
         if self.region_utm is not None:
             return self.region_utm
-        
+
         if self.region is None:
             self.region = utils.get_boundary(self.data)
-                        
+
         # corresponding UTM CRS in meters to this location
         lon, lat = np.r_[self.region.envelope.boundary.coords].mean(axis=0)
 
@@ -75,14 +75,14 @@ class PartitionSet:
         self.data = None
         self.loaded_from_file = False
         return self
-        
+
     def make_random_partitions(self, max_rectangle_size, random_variance=0.1, n_jobs=5):
         """
         makes random rectangular tiles with max_rectangle_size as maximum side length expressed in meters.
         stores result as a geopandas dataframe in self.data
         """
         assert self.data is None, "cannot make partitions over existing data"
-        
+
         self.compute_region_utm()
 
         # cut off region, assuming region_utm is expressed in meters
@@ -90,7 +90,7 @@ class PartitionSet:
 
         # reproject to epsg 4326
         self.data = gpd.GeoDataFrame({
-                                      'geometry': parts, 
+                                      'geometry': parts,
                                       'area_km2': [i.area/1e6 for i in parts]
                                       },
                                     crs = self.utm_crs).to_crs(self.epsg4326)
@@ -108,7 +108,7 @@ class PartitionSet:
 
         self.data['identifier'] =  [utils.get_region_hash(i) for i in self.data.geometry]
         return self
-        
+
     def make_grid(self, rectangle_size):
 
         """
@@ -120,7 +120,7 @@ class PartitionSet:
         assert self.data is None, "cannot make partitions over existing data"
         self.compute_region_utm()
 
-        coords = np.r_[self.region_utm.envelope.boundary.coords]        
+        coords = np.r_[self.region_utm.envelope.boundary.coords]
         m = rectangle_size
 
         minlon, minlat = coords.min(axis=0)
@@ -128,7 +128,7 @@ class PartitionSet:
         parts = []
         for slon in pbar(np.arange(minlon, maxlon, m)):
             for slat in np.arange(minlat, maxlat, m):
-                p = sh.geometry.Polygon([[slon, slat], 
+                p = sh.geometry.Polygon([[slon, slat],
                                          [slon, slat+m],
                                          [slon+m, slat+m],
                                          [slon+m, slat],
@@ -136,33 +136,34 @@ class PartitionSet:
 
                 if p.intersects(self.region_utm):
                     parts.append(p.intersection(self.region_utm))
-                    
+
         self.data = gpd.GeoDataFrame({
-                                      'geometry': parts, 
+                                      'geometry': parts,
                                       'area_km2': [i.area/1e6 for i in parts]
                                       },
                                     crs = self.utm_crs).to_crs(self.epsg4326)
         self.data['identifier'] =  [utils.get_region_hash(i) for i in self.data.geometry]
 
         return self
-    
+
     def get_downloaded_tiles_dest_dir(self, gee_image_name):
         if not 'origin_file' in dir(self):
             raise ValueError("must first save this partitions with 'save_as', or load an existing partitions file with 'from_file'")
         dest_dir = os.path.splitext(self.origin_file)[0]+ "/" + gee_image_name
         return dest_dir
-        
+
     def download_gee_tiles(self,
                         dataset_definition,
-                        n_processes=10, 
-                        pixels_lonlat=None, 
+                        ee_project,
+                        n_processes=10,
+                        pixels_lonlat=None,
                         meters_per_pixel=None,
                         remove_saturated_or_null = False,
-                        max_downloads=None, 
+                        max_downloads=None,
                         shuffle=True,
                         skip_if_exists = False,
-                        dtype = None):   
-        
+                        dtype = None):
+
         """
         see gee.download_tiles
         it will use the same folder in which the partitions where saved to or loaded from as geojson.
@@ -170,26 +171,27 @@ class PartitionSet:
 
         dest_dir = self.get_downloaded_tiles_dest_dir(dataset_definition.get_dataset_name())
         print ("saving tiles to", dest_dir, flush=True)
-         
+
         gee.download_tiles( self.data,
                             dest_dir,
+                            ee_project = ee_project,
                             dataset_definition = dataset_definition,
-                            n_processes = n_processes, 
-                            pixels_lonlat = pixels_lonlat, 
+                            n_processes = n_processes,
+                            pixels_lonlat = pixels_lonlat,
                             meters_per_pixel = meters_per_pixel,
                             remove_saturated_or_null = remove_saturated_or_null,
-                            max_downloads = max_downloads, 
+                            max_downloads = max_downloads,
                             shuffle = shuffle,
                             skip_if_exists = skip_if_exists,
                             dtype = dtype)
 
     def get_partitions(self):
         """
-        returns a list the partition objects of this partitionset 
+        returns a list the partition objects of this partitionset
         """
-        r = [Partition(partitionset = self, 
-                                        identifier = i.identifier, 
-                                        geometry = i.geometry, 
+        r = [Partition(partitionset = self,
+                                        identifier = i.identifier,
+                                        geometry = i.geometry,
                                         crs = self.data.crs) \
             for i in self.data.itertuples()]
         return r
@@ -213,7 +215,7 @@ class PartitionSet:
         self.origin_file = filename
         print (f"saved to {filename}")
         self.partitions_name = partitions_name
-        return self      
+        return self
 
     def save(self, ignore_hash=False):
         """
@@ -237,11 +239,11 @@ class PartitionSet:
         if len(cols_proportions)==0:
             print ("no proportions found in", self.origin_file)
             return
-        
+
         for col in cols_proportions:
             #self.data = self.data[[c for c in self.data.columns if not c.startswith(f"{col}__")]]
             self.data = utils.expand_dict_column(self.data, col)
-            
+
         f,ext = os.path.splitext(self.origin_file)
         expanded_fname = f'{f}_expanded{ext}'
         self.data.to_file(expanded_fname, driver='GeoJSON')
@@ -253,14 +255,14 @@ class PartitionSet:
         is an rgb image collection and image_collection_name contains segmentation masks)
         """
         def f(identifier, geometry):
-            proportions = Partition(partitionset = self, 
-                                    identifier = identifier, 
-                                    geometry = geometry, 
+            proportions = Partition(partitionset = self,
+                                    identifier = identifier,
+                                    geometry = geometry,
                                     crs = self.data.crs).compute_proportions_from_raster(
                                                                 labels_dataset_def
                                                             )
             return proportions
-        
+
         if n_jobs==1:
             r = [f(i.identifier, i.geometry) for i in pbar(self.data.itertuples(), max_value=len(self.data))]
         else:
@@ -280,7 +282,7 @@ class PartitionSet:
         foreign_ids = []
         for part in pbar(parts):
             foreign_proportions, foreign_identifier = part.compute_foreign_proportions(image_collection_name, foreign_partitionset)
-            #proportions.append({'partition_id': foreign_identifier, 
+            #proportions.append({'partition_id': foreign_identifier,
             #                    'proportions': foreign_proportions})
             proportions.append(foreign_proportions)
             foreign_ids.append(foreign_identifier)
@@ -302,11 +304,11 @@ class PartitionSet:
         self.data[f'foreignid_{foreign_name}'] = [part.compute_foreign_partition(foreign_partitionset) for part in pbar(parts)]
         self.save()
 
-    def split(self, nbands, angle, train_pct, test_pct, val_pct, split_col_name='split'):        
+    def split(self, nbands, angle, train_pct, test_pct, val_pct, split_col_name='split'):
         """
         splits the geometries in train, test, val by creating spatial bands
         and assigning each band to train, test or val according to the pcts specified.
-        
+
         nbands: the number of bands
         angle: the angle with which bands are created (in [-pi/2, pi/2])
         train_pct, test_pct, val_pct: the pcts of bands for each kind,
@@ -315,7 +317,7 @@ class PartitionSet:
         """
         if angle<-np.pi/2 or angle>np.pi/2:
             raise ValueError("angle must be between -pi/2 and pi/2")
-            
+
         p = self
         coords = np.r_[[np.r_[i.envelope.boundary.coords].mean(axis=0) for i in p.data.geometry]]
 
@@ -333,12 +335,12 @@ class PartitionSet:
 
         if bands_train + bands_test + bands_val > nbands:
             raise ValueError(f"not enough bands for specified percentages. increase nbands to at least {bands_train + bands_test + bands_val}")
-        
+
         if np.abs(angle)<np.pi/4:
             plon, plat = np.abs(angle)/(np.pi/4), 1
         else:
             plon, plat = np.sign(angle), (np.pi/2-np.abs(angle))/(np.pi/4)
-        
+
         # in case we have a small number of tiles
         crng[crng==0]=1
 
@@ -346,7 +348,7 @@ class PartitionSet:
 
         if angle<0:
             ncoords = 1-ncoords
-        
+
         # find the factor that matches the desired number of bands
         for k in np.linspace(0.1,50,10000):
             band_id = ((plon*ncoords[:,0] + plat*ncoords[:,1])/(k/nbands)).astype(int)
@@ -364,24 +366,24 @@ class PartitionSet:
         split = [band_split_map[i] for i in band_id]
 
         self.data[split_col_name] = split
-        
+
 
     def split_per_partitions(self, nbands, angle, train_pct, test_pct, val_pct, other_partitions_id):
         """
-        splits the geometries (as in 'split'), but modifies the result keeping together 
+        splits the geometries (as in 'split'), but modifies the result keeping together
         in the same split all geometries within the same partition.
-        
+
         must have previously run 'add_foreign_proportions'.
         """
-        self.split(nbands=nbands, angle=angle, 
-                  train_pct=train_pct, 
-                  test_pct=test_pct, 
+        self.split(nbands=nbands, angle=angle,
+                  train_pct=train_pct,
+                  test_pct=test_pct,
                   val_pct=val_pct, split_col_name='split')
-        
+
         self.data[f'split_{other_partitions_id}'] = self.data.groupby(f'foreignid_{other_partitions_id}')[['split']]\
                                                              .transform(lambda x: pd.Series(x).value_counts().index[0])
 
-        
+
     def save_splits(self):
         # save the split into a separate file for fast access
         fname = os.path.splitext(self.origin_file)[0] + "_splits.csv"
@@ -413,7 +415,7 @@ class PartitionSet:
 
         if len(data)==0:
             return None
-            
+
         r = cls("fromfile", data=data)
         r.origin_file = filename
         pname = re.search('_partitions_(.+?)_', filename)
@@ -424,11 +426,11 @@ class PartitionSet:
 
         r.loaded_from_file = True
 
-        return r          
+        return r
 
 
 class Partition:
-    
+
     def __init__(self, partitionset, identifier, geometry, crs):
         self.identifier = identifier
         self.geometry = geometry
@@ -441,7 +443,7 @@ class Partition:
         filename = f"{basedir}/{self.identifier}.tif"
         img = imread(filename)
         return img
-    
+
     def compute_proportions_from_raster(self, labels_dataset_def):
 
         # retrieve label array from disk
@@ -453,22 +455,22 @@ class Partition:
         # map image values according to dataset definition
         img = labels_dataset_def.map_values(img)
 
-        # account for proportions only within the geometry 
+        # account for proportions only within the geometry
         # (in case it does not match the rectangular image)
         mask = utils.get_binary_mask(self.geometry, img.shape)
         img = img[mask==1]
 
         # compute proportions
-        r = {k:v for k,v in zip(*np.unique(img, return_counts=True))}        
+        r = {k:v for k,v in zip(*np.unique(img, return_counts=True))}
         total = sum(r.values())
         r = {str(k):v/total for k,v in r.items()}
 
         return r
-    
+
     def compute_foreign_partition(self, foreign_partition_set):
         """
         returns the id of the foreign partition (geometry) intersecting this one
-        """        
+        """
         t = foreign_partition_set
         relevant = t.data[[i.intersects(self.geometry) for i in t.data.geometry.values]]
         w = np.r_[[self.geometry.intersection(i).area for i in relevant.geometry]]
@@ -486,7 +488,7 @@ class Partition:
         class proportions are computed by (1) obtaining the intersecting partitions on the
         other partitionset, (2) combining the proportions in the intersecting partitions by
         weighting them according to the intersection area with this geometry
-        
+
         returns: a list of proportions, the id of the geometry in "other_partitionset" with greater contribution
         """
         t = foreign_partition_set
@@ -505,7 +507,7 @@ class Partition:
         return foreign_proportions, largest_foreign_partition_id
 
     def compute_proportions_by_interesection(self, other_partitions):
-        pass        
+        pass
 
 
 def katana(geometry, threshold, count=0, random_variance=0.1):
@@ -516,20 +518,20 @@ def katana(geometry, threshold, count=0, random_variance=0.1):
     random_variance: 0  - try to make all rectangles of the same size
                      >0 - the greater the number, the more different the rectangle sizes
                      values between 0 and 1 seem more useful
-                     
+
     returns: a list of Polygon or MultyPolygon objects
     """
-    
-    
+
+
     """Split a Polygon into two parts across it's shortest dimension"""
     assert random_variance>=0
 
     bounds = geometry.bounds
     width = bounds[2] - bounds[0]
     height = bounds[3] - bounds[1]
-    
+
     random_factor = 2*(1+(np.random.random()-0.5)*random_variance*2)
-    
+
     if max(width, height) <= threshold or count == 250:
         # either the polygon is smaller than the threshold, or the maximum
         # number of recursions has been reached
@@ -567,25 +569,25 @@ def katana(geometry, threshold, count=0, random_variance=0.1):
 # ---- old stuff ----
 
 def flatten_geom(geom):
-    
+
     """
     recursively converts a MultiPolygon into a list of shapely shapes
     geom: a shapely geometry
-    returns: a list of geometries 
+    returns: a list of geometries
             (if 'geom' is not a multipart geometry it returns a list containing only geom)
     """
-    
+
     if isinstance(geom, list):
         geoms = geom
     elif 'geoms' in dir(geom):
         geoms = geom.geoms
     else:
         return [geom]
-        
+
     r = []
     for g in geoms:
         r.append(flatten_geom(g))
-        
+
     r = [i for j in r for i in j]
 
     return r
@@ -594,22 +596,22 @@ def change_crs(shapes, to_crs, from_crs=CRS.from_epsg(4326)):
     """
     shapes: a shapely shape or a list of shapely shapes
     from_crs: pyproj CRS object representing the CRS in which geometries are expressed
-    to_crs: pyproj CRS object with the target crs 
+    to_crs: pyproj CRS object with the target crs
 
-    returns: a GeometryCollection if 'shapes' is a shapely multi geometry 
+    returns: a GeometryCollection if 'shapes' is a shapely multi geometry
              a list of shapes if 'shapes' is a list of shapely shapes
              a shapely shape if 'shapes' is a shapely shape
     """
 
     if 'geoms' in dir(shapes):
-        r = gpd.GeoDataFrame({'geometry': list(shapes.geoms)}, crs=from_crs).to_crs(to_crs)        
+        r = gpd.GeoDataFrame({'geometry': list(shapes.geoms)}, crs=from_crs).to_crs(to_crs)
     elif isinstance (shapes, list):
-        r = gpd.GeoDataFrame({'geometry': shapes}, crs=from_crs).to_crs(to_crs)        
+        r = gpd.GeoDataFrame({'geometry': shapes}, crs=from_crs).to_crs(to_crs)
     else:
-        r = gpd.GeoDataFrame([shapes], columns=['geometry'], crs=from_crs).to_crs(to_crs)        
-        
+        r = gpd.GeoDataFrame([shapes], columns=['geometry'], crs=from_crs).to_crs(to_crs)
+
     r = list(r.to_crs(to_crs).geometry.values)
-    
+
     if 'geoms' in dir(shapes):
         r = sh.geometry.GeometryCollection(r)
     elif isinstance (shapes, list):


### PR DESCRIPTION
As of 13/11/2024, the Google Earth Engine client requires you to initialise with a Google cloud project which has earth engine enabled - see https://developers.google.com/earth-engine/guides/transition_to_cloud_projects

This PR closes issue #26 by adding support for this:
- ee project name passed to download subscript from command line
- `ee.Initialize` moved to multiprocessing pool initializer callback as project-initialised client was not being inherited by subprocesses
 > one downside of this is any initializer response message shows for each of your processes - e.g. currently, a message promoting the EE annual developer survey appears `n` times. output _could_ be silenced, but this would lead to any errors not being shown, so I chose to leave as is
- README updated with link to cloud project docs and example of passing project name to download script

I built the library and tested this on an M2 Macbook Pro and found it worked well, but have not done any more extensive testing. 